### PR TITLE
Changed the color of found text from red to green

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where a message about changed metadata would occur on saving although nothing changed. [#9159](https://github.com/JabRef/jabref/issues/9159)
 - When adding or editing a subgroup it is placed w.r.t. to alphabetical ordering rather than at the end. [koppor#577](https://github.com/koppor/jabref/issues/577)
 - We modified the Directory of Open Access Books (DOAB) fetcher so that it will now also fetch the ISBN when possible. [#8708](https://github.com/JabRef/jabref/issues/8708)
+- We changed the color of found text from red to green. [koppor#552](https://github.com/koppor/jabref/issues/552)
+
 
 ### Fixed
 

--- a/src/main/java/org/jabref/gui/entryeditor/EntryEditor.css
+++ b/src/main/java/org/jabref/gui/entryeditor/EntryEditor.css
@@ -123,6 +123,9 @@
 
 #bibtexSourceCodeArea .search {
     -fx-fill: green;
+    -fx-font-size: 1.2em;
+    -fx-font-weight: bolder;
+
 }
 
 #citationsPane {

--- a/src/main/java/org/jabref/gui/entryeditor/EntryEditor.css
+++ b/src/main/java/org/jabref/gui/entryeditor/EntryEditor.css
@@ -122,7 +122,7 @@
 }
 
 #bibtexSourceCodeArea .search {
-    -fx-fill: red;
+    -fx-fill: green;
 }
 
 #citationsPane {


### PR DESCRIPTION
Fixes https://github.com/koppor/jabref/issues/552.

This issue is about changing the text color from red to green to avoid misunderstanding in the search.

**Before:**
![Screenshot (46)](https://user-images.githubusercontent.com/110802700/197378253-10881a05-6f22-4aef-98a5-212e34a8e40d.png)


The text color of the search was red, which may make users think there was an error in the search.

**After:**
![Screenshot (47)](https://user-images.githubusercontent.com/110802700/197378283-9397154d-0867-4224-b173-32cc407a863d.png)



Highlighted the search text in green color to avoid misunderstanding.





<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->


<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

-  [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
-  [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.

I would like to know what you think about the fix.  Any comments would be appreciated. 


